### PR TITLE
feat: add nest_position param to plot_heatmaps to standardize orientation

### DIFF
--- a/deepof/config.py
+++ b/deepof/config.py
@@ -16,6 +16,7 @@ SYMMETRIC_BEHAVIORS=["nose2nose","sidebyside","sidereside"]
 ASYMMETRIC_BEHAVIORS=["nose2tail","nose2body","following"]
 CONTINUOUS_BEHAVIORS=["distance","cum-distance","speed"]
 CONTINUOUS_UNITS=["[mm]", "[mm]", "[mm/s]"]
+VALID_NEST_POSITIONS = {"top-left", "top-right", "bottom-left", "bottom-right"}
 
 ROI_COLORS = [(204, 20, 20),
        (204, 131, 20),

--- a/deepof/visuals.py
+++ b/deepof/visuals.py
@@ -34,7 +34,7 @@ import deepof.export_video
 import deepof.post_hoc
 import deepof.utils
 from deepof.data_loading import get_dt, _suppress_warning
-from deepof.config import ROI_COLORS, ARENA_COLOR, CONTINUOUS_BEHAVIORS, CONTINUOUS_UNITS, DistanceUnit, TimeUnit
+from deepof.config import ROI_COLORS, ARENA_COLOR, CONTINUOUS_BEHAVIORS, CONTINUOUS_UNITS, DistanceUnit, TimeUnit, VALID_NEST_POSITIONS
 from deepof.export_video import (
     VideoExportConfig,   
     output_annotated_video,
@@ -95,6 +95,7 @@ def plot_heatmaps(
     in_roi_criterion: str = "Center",
     # Others
     display_arena: bool = True,
+    nest_position: dict = None,
     xlim: float = None,
     ylim: float = None,
     extrapolate_heatmap: bool = True,
@@ -123,6 +124,7 @@ def plot_heatmaps(
         animals_in_roi (list): List of ids of the animals that need to be inside of the active ROI. All frames in which any of the given animals are not inside of the ROI get excluded 
         display_rois (bool): Display the active ROI, if a ROI was selected. Defaults to True.              
         display_arena (bool): whether to plot a dashed line with an overlying arena perimeter. Defaults to True.
+        nest_position (dict): maps experiment IDs to nest corner ("top-left", "top-right", "bottom-left", "bottom-right"); flips coords so nest is always top-left. Defaults to None.
         xlim (float): x-axis limits.
         ylim (float): y-axis limits.
         extrapolate_heatmap (bool): show full heatmap including extrapolated parts (default=True)
@@ -150,6 +152,11 @@ def plot_heatmaps(
     )
     if isinstance(bodyparts,str):
         bodyparts=[bodyparts]
+
+    if nest_position is not None:
+        invalid = {k: v for k, v in nest_position.items() if v not in VALID_NEST_POSITIONS}
+        if invalid:
+            raise ValueError(f"Invalid nest_position values: {invalid}." f"Must be one of: {sorted(VALID_NEST_POSITIONS)}")
 
     coords = coordinates.get_coords(center=center, align=align, return_path=False, roi_number=roi_number, in_roi_criterion=in_roi_criterion, animals_in_roi=animals_in_roi)
 
@@ -198,6 +205,18 @@ def plot_heatmaps(
         
         #cut slice from table
         tab=tab.iloc[bin_info_time[key]]
+
+        # Apply nest position flip for this experiment
+        if nest_position is not None and key in nest_position:
+            corner = nest_position[key]
+            flip_x = corner in {"top-right", "bottom-right"}
+            flip_y = corner in {"bottom-left", "bottom-right"}
+            tab = tab.copy()
+            for bp in tab.columns.get_level_values(0).unique():
+                if flip_x:
+                    tab[(bp, "x")] = -tab[(bp, "x")]
+                if flip_y:
+                    tab[(bp, "y")] = -tab[(bp, "y")]
 
         #append table
         sampled_tabs.append(tab)


### PR DESCRIPTION
Hi! I'm Caterina Barbero, I was an Amgen Scholar last summer at the MPIP. I wanted to propose this change that comes from a modification I made to my local copy of deepof during my time there.

When recording mice in home cages, the nest can be physically located at different corners of the cage depending on how it was placed under the camera. This means that across experiments, or even across videos within the same experiment, the nest appears in a different position in the heatmap. This makes it impossible to visually compare plots or draw meaningful conclusions about spatial behaviour relative to the nest.

# Changes

This PR adds a `nest_position` parameter to `plot_heatmaps()` that accepts a dict mapping each experiment ID to the corner where the nest is located in that recording:

```python
deepof.visuals.plot_heatmaps(
    my_project,
    bodyparts=["Center"],
    nest_position={
        "recording_A": "top-left",
        "recording_B": "bottom-right",
        "recording_C": "top-right",
    }
) 
```
The function flips the coordinate data for each experiment independently (before concatenation) so the nest always appears at the top-left of every heatmap. Valid corner values are "top-left", "top-right", "bottom-left", "bottom-right". Experiments not listed in the dict are left unchanged.